### PR TITLE
Spelling and grammatical improvements for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ Features:
 - Master node sends time sync message every 10s to all nodes. (this synchronizes the clocks of the nodes)
 - a message cache. If a received packet is already found in the cache --> it will not be retransmitted or handled again
 - Every message has a time stamp. If the time stamp is too old (or from the future), the message will be rejected.
-- All messages are crypted (AES128)
+- All messages are encrypted (AES128)
 - Flooding mesh support
-- TTL support (time to life)
-- ESP32, ESP2866, ESP01
+- TTL support (time to live)
+- ESP32, ESP8266, ESP01
 - Battery node support (Battery nodes do not relay messages)
 - Request&Reply support
 - Each Nodes can communicate with each other
 - Ping about 40-60ms
-- Nearly instant connection after poweron
+- Nearly instant connection after power-on
 - Retransmission support
 - Request/Reply support
 - Send and pray support (Send a message to all nodes without reply/ack)
@@ -97,7 +97,7 @@ SlaveNode-------SlaveNode-------------SlaveNode-------SlaveNode-------------Slav
 
 #define ESP_NOW_CHANNEL 1
 //AES 128bit
-unsigned char secredKey[] = {0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE, 0xFF};
+unsigned char secretKey[] = {0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE, 0xFF};
 
 void espNowFloodingMeshRecv(const uint8_t *data, int len){
   if(len>0) {
@@ -109,7 +109,7 @@ void setup() {
   Serial.begin(115200);
 
   espNowFloodingMesh_RecvCB(espNowFloodingMeshRecv);
-  espNowFloodingMesh_secredkey(secredKey);
+  espNowFloodingMesh_secredkey(secretKey);
   espNowFloodingMesh_begin(ESP_NOW_CHANNEL);
   espNowFloodingMesh_setToMasterRole(true,3); //Set ttl to 3. TIME_SYNC message use this ttl
   espNowFloodingMesh_ErrorDebugCB([](int level, const char *str) {
@@ -134,7 +134,7 @@ void loop() {
 
 #define ESP_NOW_CHANNEL 1
 //AES 128bit
-unsigned char secredKey[] = {0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF};
+unsigned char secretKey[] = {0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE,0xFF};
 
 void espNowFloodingMeshRecv(const uint8_t *data, int len){
   if(len>0) {
@@ -147,7 +147,7 @@ void setup() {
 
   espNowFloodingMesh_RecvCB(espNowFloodingMeshRecv);
   espNowFloodingMesh_begin(ESP_NOW_CHANNEL);
-  espNowFloodingMesh_secredkey(secredKey);
+  espNowFloodingMesh_secredkey(secretKey);
 
   //Ask instant sync from master.
   espNowFloodingMesh_requestInstantTimeSyncFromMaster();
@@ -175,7 +175,7 @@ void loop() {
 #include <time.h>
 #define ESP_NOW_CHANNEL 1
 //AES 128bit
-unsigned char secredKey[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+unsigned char secretKey[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
 
 void espNowFloodingMeshRecv(const uint8_t *data, int len) {
   if (len > 0) {
@@ -188,7 +188,7 @@ void setup() {
   //Set device in AP mode to begin with
   espNowFloodingMesh_RecvCB(espNowFloodingMeshRecv);
   espNowFloodingMesh_begin(ESP_NOW_CHANNEL);
-  espNowFloodingMesh_secredkey(secredKey);
+  espNowFloodingMesh_secredkey(secretKey);
   espNowFloodingMesh_setToBatteryNode();
 }
 
@@ -212,7 +212,7 @@ Send "MARCO" to other nodes
 
 #define ESP_NOW_CHANNEL 1
 //AES 128bit
-unsigned char secredKey[] = {0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE, 0xFF};
+unsigned char secretKey[] = {0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE, 0xFF};
 
 void espNowFloodingMeshRecv(const uint8_t *data, int len, uint32_t replyPrt){
 }
@@ -221,7 +221,7 @@ void setup() {
   Serial.begin(115200);
   //Set device in AP mode to begin with
   espNowFloodingMesh_RecvCB(espNowFloodingMeshRecv);
-  espNowFloodingMesh_secredkey(secredKey);
+  espNowFloodingMesh_secredkey(secretKey);
   espNowFloodingMesh_begin(ESP_NOW_CHANNEL);
   espNowFloodingMesh_setToMasterRole(true,3); //Set ttl to 3.
   espNowFloodingMesh_ErrorDebugCB([](int level, const char *str) {
@@ -251,7 +251,7 @@ Answer to "MARCO" and send "POLO"
 
 #define ESP_NOW_CHANNEL 1
 //AES 128bit
-unsigned char secredKey[] = {0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE, 0xFF};
+unsigned char secretKey[] = {0x00,0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xAA,0xBB,0xCC,0xDD,0xEE, 0xFF};
 
 void espNowFloodingMeshRecv(const uint8_t *data, int len, uint32_t replyPrt){
   if(len>0) {
@@ -269,7 +269,7 @@ void setup() {
   Serial.begin(115200);
   //Set device in AP mode to begin with
   espNowFloodingMesh_RecvCB(espNowFloodingMeshRecv);
-  espNowFloodingMesh_secredkey(secredKey);
+  espNowFloodingMesh_secredkey(secretKey);
   espNowFloodingMesh_begin(ESP_NOW_CHANNEL);
 
   espNowFloodingMesh_requestInstantTimeSyncFromMaster();


### PR DESCRIPTION
"secret" is spelled wrong in the functions too which will require work on those files, but this or addresses the readme in a way that won't affect the function yet.